### PR TITLE
Mark peer deps as optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,14 @@
     "@jitsi/windows.devices.bluetooth.advertisement": "0.2.0",
     "@jitsi/windows.storage.streams": "0.2.0"
   },
+  "peerDependenciesMeta": {
+    "@jitsi/windows.devices.bluetooth.advertisement": {
+      "optional": true
+    },
+    "@jitsi/windows.storage.streams": {
+      "optional": true
+    }
+  },
   "repository": {
     "type": "git",
     "url": "git@github.com:jitsi/spot-electron-sdk.git"


### PR DESCRIPTION
Since both `@jitsi/windows.devices.bluetooth.advertisement` and `@jitsi/windows.storage.streams` are _windows only_ packages, they need to be marked as optional, otherwise npm 8+ complains that it can't install them on macOS or linux.